### PR TITLE
Changed link to imagenet-vgg-verydeep-19.mat

### DIFF
--- a/Convolutional Neural Networks/week4/ArtTrans/README.md
+++ b/Convolutional Neural Networks/week4/ArtTrans/README.md
@@ -1,1 +1,1 @@
-You can download pretrained weights from [BaiduDrive](http://pan.baidu.com/s/1bp6jwAV)
+You can download pretrained weights from [vlfeat.org](http://www.vlfeat.org/matconvnet/models/imagenet-vgg-verydeep-19.mat)

--- a/Convolutional Neural Networks/week4/README.md
+++ b/Convolutional Neural Networks/week4/README.md
@@ -1,3 +1,3 @@
 * This week mainly focus on FaceNet and ArtTransfer
-* You can download pretrained weights for ArtTrans from [BaiduDrive](http://pan.baidu.com/s/1qYNZKL2)
+* You can download pretrained weights for ArtTrans from [vlfeat.org](http://www.vlfeat.org/matconvnet/models/imagenet-vgg-verydeep-19.mat)
 * You can download pretrained weights for FaceNet from [BaiduDrive](http://pan.baidu.com/s/1nveeGxN)


### PR DESCRIPTION
The file on Baidu is incomplete (only 27 MB, when the full file is around 510 MB), if you try to import it you will get `IOError: could not read bytes` error, so I changed links to [this site](http://www.vlfeat.org/matconvnet/pretrained/) instead.